### PR TITLE
Fix: Correct refresh token handling to prevent repeated logins

### DIFF
--- a/backend/src/controllers/user.controller.js
+++ b/backend/src/controllers/user.controller.js
@@ -351,15 +351,13 @@ const refreshAccessToken = asyncHandler(async (req, res) => {
       sameSite: isProduction ? "None" : "Lax",
     };
 
-    const { accessToken } = await generateAccessTokenAndRefreshToken(
-      user._id,
-      1
-    );
+    const { accessToken, refreshToken } = await generateAccessTokenAndRefreshToken(user._id);
 
     return res
       .status(200)
       .cookie("accessToken", accessToken, options)
-      .json(new ApiResponse(200, "Access token refreshed", { accessToken }));
+      .cookie("refreshToken", refreshToken, options)
+      .json(new ApiResponse(200, "Access token refreshed", { accessToken, refreshToken }));
   } catch (error) {
     return res.status(500).json({
       meessage: error?.message || "something went wrong",

--- a/frontend/src/fetchDetails/authService.js
+++ b/frontend/src/fetchDetails/authService.js
@@ -13,6 +13,7 @@ const fetchRefreshToken = async(navigate, toast) => {
         const resData = await response.json()
         if(resData?.data){
             localStorage.setItem("accessToken", resData?.data?.accessToken)
+            localStorage.setItem("refreshToken", resData?.data?.refreshToken)
             return resData.data.expiresIn
         }else{
             toast.error("Session expired, please login")


### PR DESCRIPTION
The previous implementation of the refresh token mechanism had an issue where the backend would generate a new refresh token upon refreshing an access token but would not send this new refresh token back to the client. The client would continue to use the old refresh token, which would then be invalid for subsequent refresh attempts, forcing you to log in again.

This commit addresses the issue by:

1.  **Backend (`user.controller.js`):**
    - Modified the `refreshAccessToken` function to send the newly generated refresh token (along with the new access token) back to the client in both the HTTP cookie and the JSON response.

2.  **Frontend (`authService.js`):**
    - Updated the `fetchRefreshToken` function to extract the new refresh token from the API response and store it in `localStorage`, ensuring that the client always uses the latest valid refresh token for future attempts.

This ensures that the refresh token cycle works correctly, allowing you to stay logged in as long as your refresh token is valid and successfully renewed.